### PR TITLE
Bugfix: Do not disconnect Koha DB handle in ReportServices controller

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/ReportServices/ReportsController.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/ReportServices/ReportsController.pm
@@ -157,7 +157,6 @@ sub getReportData {
         $_ = decode_keys($_) for @$ref;
 
         $sth->finish();
-        $dbh->disconnect();
 
         unless ($ref) {
             return $c->render(
@@ -173,7 +172,6 @@ sub getReportData {
     }
 
     catch {
-        $dbh->disconnect();
         $c->unhandled_exception($_);
     }
 }


### PR DESCRIPTION
PROBABLY that happened because some cron (non-plack) code was copied.

Or (if) .pm expected to be used from both environments, then we should move disconnects from DB to .pl / cron file only, if THAT needed.