### PR TITLE
Bugfix: Do not initialize ReportServices DB handle at load time

### DIFF
--- a/Koha/Plugin/Fi/KohaSuomi/ReportServices/ReportsController.pm
+++ b/Koha/Plugin/Fi/KohaSuomi/ReportServices/ReportsController.pm
@@ -29,35 +29,31 @@ use Koha::Plugin::Fi::KohaSuomi::ReportServices;
 use YAML::XS;
 use Koha::OAuth;
 
-my $dbh;
-
-my $module = 'C4::KohaSuomi::Tweaks';
-if (try_load($module)) {
-    warn "ReportServices C4::KohaSuomi::Tweaks loaded\n";
-    $dbh = C4::KohaSuomi::Tweaks->dbh();
-
-}
-else {
-    warn "ReportServices C4::KohaSuomi::Tweaks not loaded\n";
-    $dbh = C4::Context->dbh();
-}
-
 #This gets called from REST api
+
+sub _dbh {
+    my $module = 'C4::KohaSuomi::Tweaks';
+
+    return $module->dbh() if try_load($module);
+
+    return C4::Context->dbh();
+}
 
 sub try_load {
 
     my $mod = shift;
 
-    eval("use $mod");
+    ( my $file = $mod ) =~ s{::}{/}g;
+    $file .= '.pm';
 
-    if ($@) {
+    my $loaded = eval {
+        require $file;
+        1;
+    };
 
-        #print "\$@ = $@\n";
-        return(0);
-    }
-    else {
-        return(1);
-    }
+    return $loaded if $loaded;
+
+    return;
 }
 
 sub _d { my ($s) = @_; utf8::decode($s); $s }
@@ -149,6 +145,7 @@ sub getReportData {
 
         $log->info(("API user " . $user->borrowernumber). " " . $user->firstname . " " . $user->surname . " requested report: ReportServices API running Report with id " . $report_id . "\n");
 
+        my $dbh = _dbh();
         $sth = $dbh->prepare($sql) or die "Failed to prepare SQL for report $report_id: " . $dbh->errstr;
         
         $sth->execute() or die "Failed to execute SQL for report $report_id: " . $sth->errstr;


### PR DESCRIPTION
ReportServices can use C4::KohaSuomi::Tweaks when it is available, but that module is an optional dependency. On installations where it is not installed, falling back to C4::Context->dbh is normal behavior.

The controller tried to load C4::KohaSuomi::Tweaks and initialize a package-global database handle at package load time. Koha may load plugin API controllers while handling unrelated plugin operations, such as uploading another plugin, so the normal missing optional dependency state was logged as a warning on unrelated intranet requests:

  ReportServices C4::KohaSuomi::Tweaks not loaded

In Plack this is related to the earlier DB handle lifecycle fix. Koha manages the shared DB handle per worker, so ReportServices should not disconnect it and should not cache one at controller compile time.

Load the optional module quietly through require, keep the fallback to C4::Context->dbh silent, and resolve the database handle lazily only when getReportData() actually runs.

To test without this patch:
1. Use a Koha installation without C4::KohaSuomi::Tweaks installed.
2. Install or enable ReportServices.
3. Upload another plugin from the staff interface.
4. Check plack-intranet-error.log.
5. Notice a warning from ReportServices on the unrelated upload request, for example POST /intranet/plugins/plugins-upload.pl returning 302.

To test with this patch:
1. Use the same Koha installation without C4::KohaSuomi::Tweaks installed.
2. Upload another plugin from the staff interface.
3. Check plack-intranet-error.log.
4. Confirm there is no ReportServices warning about missing C4::KohaSuomi::Tweaks for the unrelated upload request.
5. Call the ReportServices API and confirm it still uses the normal C4::Context->dbh fallback.
6. On an installation where C4::KohaSuomi::Tweaks exists, confirm ReportServices still gets its DB handle through C4::KohaSuomi::Tweaks.